### PR TITLE
Include `sys/sysmacros.h` for to fix build

### DIFF
--- a/devices.c
+++ b/devices.c
@@ -36,6 +36,7 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 
 /* Not all libcs define these things, unfortunately... */
 #ifndef DT_UNKNOWN


### PR DESCRIPTION
Tested on Debian sid/unstable.