### PR TITLE
Fix installation race

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -Wall -Wextra
 
-pkglibexec_PROGRAMS = tiny_initramfs
+noinst_PROGRAMS = tiny_initramfs
 
 tiny_initramfs_SOURCES    = tiny_initramfs.c io.c fstab.c mount.c log.c devices.c util.c
 if ENABLE_NFS4
@@ -11,12 +11,19 @@ tiny_initramfs_LDFLAGS    = -static
 
 EXTRA_DIST = README.md tiny_initramfs.h nfs4.h
 
+installdirs-local:
+	$(MKDIR_P) "$(DESTDIR)$(pkglibexecdir)"
+
 if HAVE_VARIANT
-install-exec-hook:
-	cd $(DESTDIR)$(pkglibexecdir) && \
-		mv -f tiny_initramfs init-@VARIANT@
+install-exec-local:
+	$(MKDIR_P) "$(DESTDIR)$(pkglibexecdir)"
+	$(INSTALL_PROGRAM_ENV) $(INSTALL_PROGRAM) tiny_initramfs$(EXEEXT) "$(DESTDIR)$(pkglibexecdir)/init-@VARIANT@$(EXEEXT)"
+uninstall-local:
+	rm -f "$(DESTDIR)$(pkglibexecdir)/init-@VARIANT@$(EXEEXT)"
 else
-install-exec-hook:
-	cd $(DESTDIR)$(pkglibexecdir) && \
-		mv -f tiny_initramfs init
+install-exec-local:
+	$(MKDIR_P) "$(DESTDIR)$(pkglibexecdir)"
+	$(INSTALL_PROGRAM_ENV) $(INSTALL_PROGRAM) tiny_initramfs$(EXEEXT) "$(DESTDIR)$(pkglibexecdir)/init$(EXEEXT)"
+uninstall-local:
+	rm -f "$(DESTDIR)$(pkglibexecdir)/init$(EXEEXT)"
 endif


### PR DESCRIPTION
The Debian packaging builds tiny-initramfs twice with different variant names and installs both into the same directory. If the build uses multiple threads this can lead to a race condition between the copying of the init binary and the renaming.

This commit fixes the issue at the root by eliminating the separate steps and combining the installation and renaming into one invocation.